### PR TITLE
Oauth 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   "devDependencies": {
     "@types/express": "^4.17.9",
     "@types/jsonwebtoken": "^8.5.0",
+    "@types/mongoose": "^5.10.1",
     "@types/passport": "^1.0.4",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
-    "@types/mongoose": "^5.10.1",
     "eslint": "^7.13.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^6.15.0",
@@ -46,6 +46,7 @@
     "passport-github": "^1.1.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.0",
-    "passport-naver": "^1.0.6"
+    "passport-naver": "^1.0.6",
+    "url": "^0.11.0"
   }
 }

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,0 +1,12 @@
+import * as express from 'express';
+
+const getUser = async (req: express.Request, res: express.Response) => {
+  try {
+    const { user } = req;
+    res.json(user);
+  } catch (e) {
+    res.json(e);
+  }
+};
+
+export default { getUser };

--- a/src/routes/UserRoute.ts
+++ b/src/routes/UserRoute.ts
@@ -1,0 +1,8 @@
+import * as express from 'express';
+import UserController from '../controllers/UserController';
+
+const router: express.Router = express();
+
+router.get('/', UserController.getUser);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,13 +1,26 @@
 import * as express from 'express';
+import * as passport from 'passport';
 import loginRouter from './auth/Login';
 import logRouter from './log/Log';
+<<<<<<< HEAD
 import projectRouter from './ProjectRoute';
+=======
+import userRouter from './UserRoute';
+>>>>>>> feat: User 조회 로직 추가
 
 const router: express.Router = express();
 
 router.use('/oauth', loginRouter);
 router.use('/log', logRouter);
+<<<<<<< HEAD
 router.use('/project', projectRouter);
+=======
+router.use(
+  '/user',
+  passport.authenticate('jwt', { session: false }),
+  userRouter
+);
+>>>>>>> feat: User 조회 로직 추가
 
 router.get('/', (req: express.Request, res: express.Response) => {
   res.send('hello typescript express!');

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,25 +2,19 @@ import * as express from 'express';
 import * as passport from 'passport';
 import loginRouter from './auth/Login';
 import logRouter from './log/Log';
-<<<<<<< HEAD
 import projectRouter from './ProjectRoute';
-=======
 import userRouter from './UserRoute';
->>>>>>> feat: User 조회 로직 추가
 
 const router: express.Router = express();
 
 router.use('/oauth', loginRouter);
 router.use('/log', logRouter);
-<<<<<<< HEAD
 router.use('/project', projectRouter);
-=======
 router.use(
   '/user',
   passport.authenticate('jwt', { session: false }),
   userRouter
 );
->>>>>>> feat: User 조회 로직 추가
 
 router.get('/', (req: express.Request, res: express.Response) => {
   res.send('hello typescript express!');

--- a/src/services/LoginService.ts
+++ b/src/services/LoginService.ts
@@ -1,25 +1,25 @@
 import User from '../models/User';
 
-const loginService = {
-  saveData: async (user: any, domain: string) => {
-    const { id, displayName, username, emails, photos } = user;
-    const [email] = emails || [{ value: null }];
-    const [photo] = photos;
-    const oauthId = `${id}_${domain}`;
+const saveData = async (user: any, domain: string) => {
+  const { id, displayName, username, emails, photos } = user;
+  const [email] = emails || [{ value: null }];
+  const [photo] = photos;
+  const oauthId = `${id}_${domain}`;
 
-    const conditions = { oauthId };
-    const docs = Object({
-      name: displayName || username,
-      email: email.value,
-      imageURL: photo.value,
-      oauthId,
-      status: true,
-    });
+  const conditions = { oauthId };
+  const docs = Object({
+    name: displayName || username,
+    email: email.value,
+    imageURL: photo.value,
+    oauthId,
+    status: true,
+  });
 
-    const one = await User.findOne(conditions);
-    const userData = one || (await User.create(docs));
-    return userData;
-  },
+  const one = await User.findOne(conditions);
+  const temp = one || (await User.create(docs));
+  const userId = temp._id;
+  const userStatus = temp.status;
+  return [userId, userStatus];
 };
 
-export default loginService;
+export default { saveData };

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,0 +1,16 @@
+import User from '../models/User';
+
+const findUser = async (id: string) => {
+  const one = await User.findById(id);
+  const user = {
+    name: one.name,
+    email: one.email,
+    imageURL: one.imageURL,
+    status: one.status,
+    projects: one.projects,
+    recentProject: one.recentProject,
+  };
+  return user;
+};
+
+export default { findUser };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,6 +2270,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -2286,6 +2291,11 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -2852,6 +2862,14 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
**요약** 

로그인시 JWT 발급 과정을 추가하고, JWT를 이용해 유저 인증에 사용할 미들웨어를 추가했습니다.

**내용**

- 로그인시 JWT를 발급하고 메인페이지로 `redirect`됩니다. 
  - `redirect`시 `query`에 토큰 정보를 추가해서 보내줍니다. 
  - `query`에 토큰 정보를 추가할때 사용할 `url`모듈을 설치했습니다. 
  - 쿼리에 담아보내는 방법이 사실 만족스럽지 않기 때문에...다른 좋은 의견이 있다면 반영하겠습니다...
  - 네이버 로그인은 추후에 사용하지 않을 가능성이 높기 때문에 토큰 발급 과정을 추가하지 않았습니다. 
- `passport`의 `JwtStrategy`에서 헤더에 있는 토큰 정보를 활용해 유저를 식별하도록 했습니다. 
  - 라우터에서 미들웨어로 사용해 인증된 사용자만 요청을 처리하도록 할 수 있습니다. 
- 유저 정보를 admin 페이지에서 가져올때 사용할 API를 추가했습니다. 