### PR TITLE
프로젝트 api 구현 & 권한 설정 api 

### DIFF
--- a/src/controllers/LoginController.ts
+++ b/src/controllers/LoginController.ts
@@ -15,7 +15,7 @@ const googleLogin = (req: express.Request, res: express.Response) => {
       if (err) return false;
 
       const [userId, userStatus] = await LoginService.saveData(user, 'google');
-      const token = jwt.sign({ userId }, process.env.JWT_SECRET);
+      const token: string = jwt.sign({ userId }, process.env.JWT_SECRET);
 
       if (!userStatus) throw new Error('deleted user');
 
@@ -40,7 +40,7 @@ const githubLogin = (req: express.Request, res: express.Response) => {
       if (err) return false;
 
       const [userId, userStatus] = await LoginService.saveData(user, 'github');
-      const token = jwt.sign({ userId }, process.env.JWT_SECRET);
+      const token: string = jwt.sign({ userId }, process.env.JWT_SECRET);
 
       if (!userStatus) throw new Error('deleted user');
 

--- a/src/controllers/LoginController.ts
+++ b/src/controllers/LoginController.ts
@@ -1,7 +1,6 @@
 import * as express from 'express';
 import * as passport from 'passport';
 import * as jwt from 'jsonwebtoken';
-import * as url from 'url';
 import * as dotenv from 'dotenv';
 import LoginService from '../services/LoginService';
 
@@ -19,13 +18,10 @@ const googleLogin = (req: express.Request, res: express.Response) => {
 
       if (!userStatus) throw new Error('deleted user');
 
-      if (token)
-        return res.redirect(
-          url.format({
-            pathname: process.env.ADMIN_ADDR_MAIN,
-            query: { token },
-          })
-        );
+      if (token) {
+        res.cookie('jwt', token, { domain: 'localhost', httpOnly: true });
+        return res.redirect(process.env.ADMIN_ADDR_MAIN);
+      }
 
       throw new Error('not found token');
     }
@@ -44,13 +40,10 @@ const githubLogin = (req: express.Request, res: express.Response) => {
 
       if (!userStatus) throw new Error('deleted user');
 
-      if (token)
-        return res.redirect(
-          url.format({
-            pathname: process.env.ADMIN_ADDR_MAIN,
-            query: { token },
-          })
-        );
+      if (token) {
+        res.cookie('jwt', token, { domain: 'localhost', httpOnly: true });
+        return res.redirect(process.env.ADMIN_ADDR_MAIN);
+      }
 
       throw new Error('not found token');
     }

--- a/src/controllers/ProjectController.ts
+++ b/src/controllers/ProjectController.ts
@@ -47,4 +47,23 @@ const postMember = async (req: express.Request, res: express.Response) => {
   }
 };
 
-export default { postProject, getProject, deleteProject, postMember };
+const deleteMember = async (req: express.Request, res: express.Response) => {
+  try {
+    const result = await ProjectService.removeMember(
+      req.user,
+      req.params.projectId,
+      req.params.memberId
+    );
+    res.json(result);
+  } catch (err) {
+    res.json(err);
+  }
+};
+
+export default {
+  postProject,
+  getProject,
+  deleteProject,
+  postMember,
+  deleteMember,
+};

--- a/src/controllers/ProjectController.ts
+++ b/src/controllers/ProjectController.ts
@@ -1,9 +1,13 @@
 import * as express from 'express';
+import { ProjectDocument } from '../models/Project';
 import ProjectService from '../services/ProjectService';
 
 const postProject = async (req: express.Request, res: express.Response) => {
   try {
-    const result = await ProjectService.createProject(req.user, req.body);
+    const result: ProjectDocument = await ProjectService.createProject(
+      req.user,
+      req.body
+    );
     res.json(result);
   } catch (err) {
     res.json(err);
@@ -12,7 +16,7 @@ const postProject = async (req: express.Request, res: express.Response) => {
 
 const getProject = async (req: express.Request, res: express.Response) => {
   try {
-    const result = await ProjectService.readProject(
+    const result: ProjectDocument | any = await ProjectService.readProject(
       req.user,
       req.params.projectId
     );
@@ -24,7 +28,7 @@ const getProject = async (req: express.Request, res: express.Response) => {
 
 const deleteProject = async (req: express.Request, res: express.Response) => {
   try {
-    const result = await ProjectService.removeProject(
+    const result: ProjectDocument = await ProjectService.removeProject(
       req.user,
       req.params.projectId
     );
@@ -36,7 +40,7 @@ const deleteProject = async (req: express.Request, res: express.Response) => {
 
 const postMember = async (req: express.Request, res: express.Response) => {
   try {
-    const result = await ProjectService.pushMember(
+    const result: ProjectDocument = await ProjectService.pushMember(
       req.user,
       req.params.projectId,
       req.body
@@ -49,7 +53,7 @@ const postMember = async (req: express.Request, res: express.Response) => {
 
 const deleteMember = async (req: express.Request, res: express.Response) => {
   try {
-    const result = await ProjectService.removeMember(
+    const result: ProjectDocument = await ProjectService.removeMember(
       req.user,
       req.params.projectId,
       req.params.memberId

--- a/src/controllers/ProjectController.ts
+++ b/src/controllers/ProjectController.ts
@@ -12,7 +12,10 @@ const postProject = async (req: express.Request, res: express.Response) => {
 
 const getProject = async (req: express.Request, res: express.Response) => {
   try {
-    const result = await ProjectService.readProject(req.params.projectId);
+    const result = await ProjectService.readProject(
+      req.user,
+      req.params.projectId
+    );
     res.json(result);
   } catch (err) {
     res.json(err);

--- a/src/controllers/ProjectController.ts
+++ b/src/controllers/ProjectController.ts
@@ -34,4 +34,17 @@ const deleteProject = async (req: express.Request, res: express.Response) => {
   }
 };
 
-export default { postProject, getProject, deleteProject };
+const postMember = async (req: express.Request, res: express.Response) => {
+  try {
+    const result = await ProjectService.pushMember(
+      req.user,
+      req.params.projectId,
+      req.body
+    );
+    res.json(result);
+  } catch (err) {
+    res.json(err);
+  }
+};
+
+export default { postProject, getProject, deleteProject, postMember };

--- a/src/controllers/ProjectController.ts
+++ b/src/controllers/ProjectController.ts
@@ -24,7 +24,10 @@ const getProject = async (req: express.Request, res: express.Response) => {
 
 const deleteProject = async (req: express.Request, res: express.Response) => {
   try {
-    const result = await ProjectService.removeProject(req.params.projectId);
+    const result = await ProjectService.removeProject(
+      req.user,
+      req.params.projectId
+    );
     res.json(result);
   } catch (err) {
     res.json(err);

--- a/src/controllers/ProjectController.ts
+++ b/src/controllers/ProjectController.ts
@@ -3,10 +3,10 @@ import ProjectService from '../services/ProjectService';
 
 const postProject = async (req: express.Request, res: express.Response) => {
   try {
-    const result = await ProjectService.createProject(req.body);
+    const result = await ProjectService.createProject(req.user, req.body);
     res.json(result);
-  } catch (e) {
-    res.json(e);
+  } catch (err) {
+    res.json(err);
   }
 };
 
@@ -14,8 +14,8 @@ const getProject = async (req: express.Request, res: express.Response) => {
   try {
     const result = await ProjectService.readProject(req.params.projectId);
     res.json(result);
-  } catch (e) {
-    res.json(e);
+  } catch (err) {
+    res.json(err);
   }
 };
 
@@ -23,8 +23,8 @@ const deleteProject = async (req: express.Request, res: express.Response) => {
   try {
     const result = await ProjectService.removeProject(req.params.projectId);
     res.json(result);
-  } catch (e) {
-    res.json(e);
+  } catch (err) {
+    res.json(err);
   }
 };
 

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,12 +1,21 @@
 import * as express from 'express';
+import UserService from '../services/UserService';
 
 const getUser = async (req: express.Request, res: express.Response) => {
   try {
-    const { user } = req;
-    res.json(user);
-  } catch (e) {
-    res.json(e);
+    res.json(req.user);
+  } catch (err) {
+    res.json(err);
   }
 };
 
-export default { getUser };
+const getProjects = async (req: express.Request, res: express.Response) => {
+  try {
+    const result = await UserService.readProjects(req.user);
+    res.json(result);
+  } catch (err) {
+    res.json(err);
+  }
+};
+
+export default { getUser, getProjects };

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -11,7 +11,7 @@ const getUser = async (req: express.Request, res: express.Response) => {
 
 const getProjects = async (req: express.Request, res: express.Response) => {
   try {
-    const result = await UserService.readProjects(req.user);
+    const result: {} = await UserService.readProjects(req.user);
     res.json(result);
   } catch (err) {
     res.json(err);

--- a/src/passport.ts
+++ b/src/passport.ts
@@ -2,7 +2,7 @@ import * as passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { Strategy as GitHubStrategy } from 'passport-github';
 import { Strategy as NaverStrategy } from 'passport-naver';
-import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
+import { Strategy as JwtStrategy } from 'passport-jwt';
 import * as dotenv from 'dotenv';
 import UserService from './services/UserService';
 
@@ -50,10 +50,14 @@ const initPassport = () => {
     )
   );
 
+  const cookieExtractor = req => {
+    return req.cookies ? req.cookies.jwt : undefined;
+  };
+
   passport.use(
     new JwtStrategy(
       {
-        jwtFromRequest: ExtractJwt.fromHeader('authorization'),
+        jwtFromRequest: cookieExtractor,
         secretOrKey: process.env.JWT_SECRET,
       },
       async (payload, done) => {

--- a/src/routes/ProjectRoute.ts
+++ b/src/routes/ProjectRoute.ts
@@ -7,5 +7,6 @@ router.post('/', ProjectController.postProject);
 router.get('/:projectId', ProjectController.getProject);
 router.delete('/:projectId', ProjectController.deleteProject);
 router.post('/:projectId/member', ProjectController.postMember);
+router.delete('/:projectId/member/:memberId', ProjectController.deleteMember);
 
 export default router;

--- a/src/routes/ProjectRoute.ts
+++ b/src/routes/ProjectRoute.ts
@@ -6,5 +6,6 @@ const router: express.Router = express();
 router.post('/', ProjectController.postProject);
 router.get('/:projectId', ProjectController.getProject);
 router.delete('/:projectId', ProjectController.deleteProject);
+router.post('/:projectId/member', ProjectController.postMember);
 
 export default router;

--- a/src/routes/UserRoute.ts
+++ b/src/routes/UserRoute.ts
@@ -4,5 +4,6 @@ import UserController from '../controllers/UserController';
 const router: express.Router = express();
 
 router.get('/', UserController.getUser);
+router.get('/projects', UserController.getProjects);
 
 export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -9,7 +9,11 @@ const router: express.Router = express();
 
 router.use('/oauth', loginRouter);
 router.use('/log', logRouter);
-router.use('/project', projectRouter);
+router.use(
+  '/project',
+  passport.authenticate('jwt', { session: false }),
+  projectRouter
+);
 router.use(
   '/user',
   passport.authenticate('jwt', { session: false }),

--- a/src/services/LoginService.ts
+++ b/src/services/LoginService.ts
@@ -1,4 +1,4 @@
-import User from '../models/User';
+import User, { UserDocument } from '../models/User';
 
 const saveData = async (user: any, domain: string) => {
   const { id, displayName, username, emails, photos } = user;
@@ -15,10 +15,10 @@ const saveData = async (user: any, domain: string) => {
     status: true,
   });
 
-  const one = await User.findOne(conditions);
-  const temp = one || (await User.create(docs));
-  const userId = temp._id;
-  const userStatus = temp.status;
+  const one: UserDocument = await User.findOne(conditions);
+  const temp: UserDocument = one || (await User.create(docs));
+  const userId: any = temp._id;
+  const userStatus: Boolean = temp.status;
   return [userId, userStatus];
 };
 

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -1,5 +1,5 @@
-import Project from '../models/Project';
-import User from '../models/User';
+import Project, { ProjectDocument } from '../models/Project';
+import User, { UserDocument } from '../models/User';
 
 const createProject = async (user: any, data: any) => {
   const { userId } = user;
@@ -13,8 +13,8 @@ const createProject = async (user: any, data: any) => {
   });
 
   try {
-    const project = await Project.create(docs);
-    const updatedUser = await User.findByIdAndUpdate(
+    const project: ProjectDocument = await Project.create(docs);
+    const updatedUser: UserDocument = await User.findByIdAndUpdate(
       userId,
       {
         $push: { projects: project._id },
@@ -30,14 +30,14 @@ const createProject = async (user: any, data: any) => {
 
 const readProject = async (user: any, projectId: string) => {
   const { userId } = user;
-  const project = await Project.findById(projectId);
+  const project: ProjectDocument = await Project.findById(projectId);
   if (String(project.owner) === userId || project.members.includes(userId))
     return project;
   return 'no permission';
 };
 
 const removeProject = async (user: any, projectId: string) => {
-  const deletedProject = await Project.findOneAndDelete({
+  const deletedProject: ProjectDocument = await Project.findOneAndDelete({
     _id: projectId,
     owner: user.userId,
   });
@@ -45,10 +45,10 @@ const removeProject = async (user: any, projectId: string) => {
   const allMembers = [...members, owner];
 
   const promiseMembers = allMembers.map(async memberId => {
-    const member = await User.findById(memberId);
+    const member: UserDocument = await User.findById(memberId);
     const newRecentProject =
       String(member.recentProject) === projectId ? null : member.recentProject;
-    const updatedMember = await User.findByIdAndUpdate(
+    const updatedMember: UserDocument = await User.findByIdAndUpdate(
       memberId,
       {
         $pull: { projects: Object(projectId) },
@@ -58,7 +58,7 @@ const removeProject = async (user: any, projectId: string) => {
     );
     return updatedMember;
   });
-  const updatedMembers = await Promise.all(promiseMembers);
+  const updatedMembers: UserDocument[] = await Promise.all(promiseMembers);
 
   return deletedProject;
 };
@@ -66,7 +66,7 @@ const removeProject = async (user: any, projectId: string) => {
 const pushMember = async (user: any, projectId: string, data: any) => {
   const { userId } = user;
   const { member } = data;
-  const updatedProject = await Project.findOneAndUpdate(
+  const updatedProject: ProjectDocument = await Project.findOneAndUpdate(
     {
       _id: projectId,
       owner: userId,
@@ -76,7 +76,7 @@ const pushMember = async (user: any, projectId: string, data: any) => {
     },
     { new: true }
   );
-  const updatedUser = await User.findByIdAndUpdate(
+  const updatedUser: UserDocument = await User.findByIdAndUpdate(
     member,
     {
       $addToSet: { projects: updatedProject._id },
@@ -88,7 +88,7 @@ const pushMember = async (user: any, projectId: string, data: any) => {
 
 const removeMember = async (user: any, projectId: string, memberId: string) => {
   const { userId } = user;
-  const updatedProject = await Project.findOneAndUpdate(
+  const updatedProject: ProjectDocument = await Project.findOneAndUpdate(
     {
       _id: projectId,
       owner: userId,
@@ -98,7 +98,7 @@ const removeMember = async (user: any, projectId: string, memberId: string) => {
     },
     { new: true }
   );
-  const updatedUser = await User.findByIdAndUpdate(
+  const updatedUser: UserDocument = await User.findByIdAndUpdate(
     memberId,
     {
       $pull: { projects: updatedProject._id },

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -1,19 +1,31 @@
 import Project from '../models/Project';
+import User from '../models/User';
 
-// 유저 정보는 JWT에서 가져올것
-// 유저 정보에도 프로젝트 정보를 추가할 것
-const createProject = async (data: any) => {
+const createProject = async (user: any, data: any) => {
+  const { userId } = user;
   const { title, description, framework, dsn } = data;
-
   const docs = Object({
     title,
     description,
     framework,
     dsn,
+    owner: userId,
   });
 
-  const result = await Project.create(docs);
-  return result;
+  try {
+    const project = await Project.create(docs);
+    const updatedUser = await User.findByIdAndUpdate(
+      userId,
+      {
+        $push: { projects: project._id },
+        $set: { recentProject: project._id },
+      },
+      { new: true }
+    );
+    return project;
+  } catch (err) {
+    return err;
+  }
 };
 
 // members에 요청을 보낸 유저가 존재할 경우 결과를 반환할 것

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -88,4 +88,32 @@ const pushMember = async (user: any, projectId: string, data: any) => {
   return updatedProject;
 };
 
-export default { createProject, readProject, removeProject, pushMember };
+const removeMember = async (user: any, projectId: string, memberId: string) => {
+  const { userId } = user;
+  const updatedProject = await Project.findOneAndUpdate(
+    {
+      _id: projectId,
+      owner: userId,
+    },
+    {
+      $pull: { members: Object(memberId) },
+    },
+    { new: true }
+  );
+  const updatedUser = await User.findByIdAndUpdate(
+    memberId,
+    {
+      $pull: { projects: updatedProject._id },
+    },
+    { new: true }
+  );
+  return updatedProject;
+};
+
+export default {
+  createProject,
+  readProject,
+  removeProject,
+  pushMember,
+  removeMember,
+};

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -65,4 +65,27 @@ const removeProject = async (user: any, projectId: string) => {
   return deletedProject;
 };
 
-export default { createProject, readProject, removeProject };
+const pushMember = async (user: any, projectId: string, data: any) => {
+  const { userId } = user;
+  const { member } = data;
+  const updatedProject = await Project.findOneAndUpdate(
+    {
+      _id: projectId,
+      owner: userId,
+    },
+    {
+      $addToSet: { members: member },
+    },
+    { new: true }
+  );
+  const updatedUser = await User.findByIdAndUpdate(
+    member,
+    {
+      $addToSet: { projects: updatedProject._id },
+    },
+    { new: true }
+  );
+  return updatedProject;
+};
+
+export default { createProject, readProject, removeProject, pushMember };

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -28,10 +28,12 @@ const createProject = async (user: any, data: any) => {
   }
 };
 
-// members에 요청을 보낸 유저가 존재할 경우 결과를 반환할 것
-const readProject = async (projectId: string) => {
+const readProject = async (user: any, projectId: string) => {
+  const { userId } = user;
   const project = await Project.findById(projectId);
-  return project;
+  if (String(project.owner) === userId || project.members.includes(userId))
+    return project;
+  return 'no permission';
 };
 
 // 유저 정보에 있는 project 정보도 삭제할것

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -48,13 +48,11 @@ const removeProject = async (user: any, projectId: string) => {
     const member = await User.findById(memberId);
     const newRecentProject =
       String(member.recentProject) === projectId ? null : member.recentProject;
-    const newProjects = member.projects.filter(
-      project => String(project) !== projectId
-    );
     const updatedMember = await User.findByIdAndUpdate(
       memberId,
       {
-        $set: { recentProject: newRecentProject, projects: newProjects },
+        $pull: { projects: Object(projectId) },
+        $set: { recentProject: newRecentProject },
       },
       { new: true }
     );

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -14,4 +14,13 @@ const findUser = async (id: string) => {
   return user;
 };
 
-export default { findUser };
+const readProjects = async (user: any) => {
+  const { projects } = await User.findOne({ _id: user.userId }).populate({
+    path: 'projects',
+    model: 'Project',
+    select: 'title',
+  });
+  return projects;
+};
+
+export default { findUser, readProjects };

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -3,6 +3,7 @@ import User from '../models/User';
 const findUser = async (id: string) => {
   const one = await User.findById(id);
   const user = {
+    userId: id,
     name: one.name,
     email: one.email,
     imageURL: one.imageURL,

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,7 +1,7 @@
-import User from '../models/User';
+import User, { UserDocument } from '../models/User';
 
 const findUser = async (id: string) => {
-  const one = await User.findById(id);
+  const one: UserDocument = await User.findById(id);
   const user = {
     userId: id,
     name: one.name,


### PR DESCRIPTION
**요약** 

프로젝트 API에 유저 정보를 추가하고, 권한 설정 API를 구현했습니다. 

**내용**

- 프로젝트 API
  - 프로젝트 생성시 `owner`에 생성한 유저의 정보를 추가합니다. 
  - 프로젝트 생성시 유저 정보에 프로젝트 정보를 추가합니다. 
  - 프로젝트 정보 조회시 `owner`혹은 `members`에 포함된 유저만 정보를 확인할 수 있도록 했습니다. 
  - 프로젝트 삭제시 `owner` 권한이 있는 경우에만 삭제하도록 했습니다. 
  - 프로젝트 삭제시 속해 있는 유저의 도큐멘트에서 프로젝트 정보를 삭제합니다. 
- 권한 설정 API
  - `owner` 권한이 있는 사용자가 요청할 경우 멤버를 추가하거나 삭제할 수 있도록 했습니다. 
  - 멤버의 도큐멘트에서 프로젝트 추가, 삭제도 함께 실행됩니다. 
- 프로젝트 제목 조회 API 
  - 유저가 속해 있는 프로젝트의 `title`을 가져오는 API를 추가했습니다. 

**고민중인 내용**

`mongoose`에서 트랜잭션 사용시에 DB 레플리카 셋이 필요하다는 설명이 있어서 생략했습니다...만...
추후에 기회가 된다면 추가해보도록 하겠습니다. 

**추가 변경사항**

- 함수의 값을 받을 때 타입을 지정하도록 변경했습니다. 
- JWT 저장 방식을 쿠키로 다시 변경했습니다. 