### PR TITLE
error endpoint에 dsn 적용, issue api 추가 등

### DIFF
--- a/src/controllers/ErrorEventController.ts
+++ b/src/controllers/ErrorEventController.ts
@@ -9,7 +9,9 @@ const collectErrorEvent = async (
   res: express.Response
   // next: express.NextFunction
 ) => {
-  const data = req.body;
+  const { projectId } = req.params;
+
+  const data = { ...req.body, projectId };
   console.log(data);
 
   try {

--- a/src/controllers/ErrorEventController.ts
+++ b/src/controllers/ErrorEventController.ts
@@ -36,6 +36,19 @@ const getAllErrorEvents = async (
   }
 };
 
+const getErrorEvent = async (req: express.Request, res: express.Response) => {
+  try {
+    const { errorEventId } = req.params;
+    const errorEvent: ErrorEventDocument = await errorEventService.getErrorEvent(
+      errorEventId
+    );
+    res.json(errorEvent);
+  } catch (err) {
+    console.error(err);
+    res.json(err);
+  }
+};
+
 const listIssueErrorEvents = async (
   req: express.Request,
   res: express.Response
@@ -52,4 +65,9 @@ const listIssueErrorEvents = async (
   }
 };
 
-export default { collectErrorEvent, getAllErrorEvents, listIssueErrorEvents };
+export default {
+  collectErrorEvent,
+  getAllErrorEvents,
+  getErrorEvent,
+  listIssueErrorEvents,
+};

--- a/src/controllers/IssueController.ts
+++ b/src/controllers/IssueController.ts
@@ -21,7 +21,7 @@ const listProjectIssues = async (
 ) => {
   const projectId = new mongoose.Types.ObjectId(req.params.projectId);
 
-  const issuelist: IssueDocument[] = await issueService.getIssueListOfProject(
+  const issuelist: IssueDocument[] = await issueService.getIssueListByProjectId(
     projectId
   );
   res.json(issuelist);

--- a/src/controllers/IssueController.ts
+++ b/src/controllers/IssueController.ts
@@ -1,15 +1,30 @@
 import * as express from 'express';
-import { IssueDocument } from '../models/Issue';
-
+import * as mongoose from 'mongoose';
+import Issue, { IssueDocument } from '../models/Issue';
 import * as issueService from '../services/IssueService';
 
-const listAllIssues = async (
-  req: express.Request,
-  res: express.Response
-  // next: express.NextFunction
-) => {
+const listAllIssues = async (req: express.Request, res: express.Response) => {
   const issueList: IssueDocument[] = await issueService.getAllIssue();
   res.json(issueList);
 };
 
-export default { listAllIssues };
+const issueDetail = async (req: express.Request, res: express.Response) => {
+  const { issueId } = req.params;
+  console.log(issueId);
+  const issue: IssueDocument = await issueService.getIssue(issueId);
+  res.json(issue);
+};
+
+const listProjectIssues = async (
+  req: express.Request,
+  res: express.Response
+) => {
+  const projectId = new mongoose.Types.ObjectId(req.params.projectId);
+
+  const issuelist: IssueDocument[] = await issueService.getIssueListOfProject(
+    projectId
+  );
+  res.json(issuelist);
+};
+
+export default { listAllIssues, issueDetail, listProjectIssues };

--- a/src/controllers/IssueController.ts
+++ b/src/controllers/IssueController.ts
@@ -10,7 +10,6 @@ const listAllIssues = async (req: express.Request, res: express.Response) => {
 
 const issueDetail = async (req: express.Request, res: express.Response) => {
   const { issueId } = req.params;
-  console.log(issueId);
   const issue: IssueDocument = await issueService.getIssue(issueId);
   res.json(issue);
 };

--- a/src/models/ErrorEvent.ts
+++ b/src/models/ErrorEvent.ts
@@ -1,7 +1,14 @@
 import * as mongoose from 'mongoose';
 
 export const ErrorEventSchema: mongoose.Schema = new mongoose.Schema({
+  name: String,
+  message: String,
+  stack: String,
   content: String,
+  issueId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Issue',
+  },
   projectId: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Project',
@@ -11,19 +18,21 @@ export const ErrorEventSchema: mongoose.Schema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
-  userInfo: {},
-  tags: [[String, String]],
+  tags: {},
   hash: String,
 });
 
 export interface ErrorEventDocument extends mongoose.Document {
+  name: String;
+  message: String;
+  stack: String;
   content: String;
   date: Date;
   errArea: mongoose.Schema.Types.Mixed;
-  userInfo: {};
-  tags: [[String, String]];
+  tags: {};
   hash: String;
-  projectId: mongoose.Schema.Types.ObjectId;
+  issueId: mongoose.Types.ObjectId;
+  projectId: mongoose.Types.ObjectId;
 }
 
 const ErrorEvent: mongoose.Model<ErrorEventDocument> = mongoose.model(

--- a/src/models/Issue.ts
+++ b/src/models/Issue.ts
@@ -35,6 +35,7 @@ export interface IssueDocument extends mongoose.Document {
   description: String;
   comments: CommentDocument[];
   errorEvents: ErrorEventDocument[];
+  projectId: mongoose.Types.ObjectId;
 }
 
 const Issue: mongoose.Model<IssueDocument> = mongoose.model(

--- a/src/models/Issue.ts
+++ b/src/models/Issue.ts
@@ -4,6 +4,17 @@ import { CommentSchema, CommentDocument } from './Comment';
 
 const IssueSchema: mongoose.Schema = new mongoose.Schema(
   {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    message: {
+      type: String,
+    },
+    stack: {
+      type: String,
+    },
     projectId: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Project',
@@ -11,17 +22,12 @@ const IssueSchema: mongoose.Schema = new mongoose.Schema(
     groupHash: {
       type: String,
     },
-    title: {
-      type: String,
-      required: true,
-      trim: true,
-    },
-    description: {
-      type: String,
-    },
-
-    errorEvents: [ErrorEventSchema],
-
+    errorEvents: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'ErrorEvent',
+      },
+    ],
     comments: [CommentSchema],
   },
   {
@@ -30,11 +36,12 @@ const IssueSchema: mongoose.Schema = new mongoose.Schema(
 );
 
 export interface IssueDocument extends mongoose.Document {
+  name: String;
+  message: String;
+  stack: String;
   groupHash: String;
-  title: String;
-  description: String;
   comments: CommentDocument[];
-  errorEvents: ErrorEventDocument[];
+  errorEvents: mongoose.Types.ObjectId[];
   projectId: mongoose.Types.ObjectId;
 }
 

--- a/src/routes/Error.ts
+++ b/src/routes/Error.ts
@@ -5,4 +5,5 @@ const router: express.Router = express();
 
 router.post('/:projectId', ErrorController.collectErrorEvent);
 router.get('/', ErrorController.getAllErrorEvents);
+router.get('/issue/:issueId', ErrorController.listIssueErrorEvents);
 export default router;

--- a/src/routes/Error.ts
+++ b/src/routes/Error.ts
@@ -5,5 +5,6 @@ const router: express.Router = express();
 
 router.post('/:projectId', ErrorController.collectErrorEvent);
 router.get('/', ErrorController.getAllErrorEvents);
+router.get('/:errorEventId', ErrorController.getErrorEvent);
 router.get('/issue/:issueId', ErrorController.listIssueErrorEvents);
 export default router;

--- a/src/routes/Error.ts
+++ b/src/routes/Error.ts
@@ -3,6 +3,6 @@ import ErrorController from '../controllers/ErrorEventController';
 
 const router: express.Router = express();
 
-router.post('/', ErrorController.collectErrorEvent);
+router.post('/:projectId', ErrorController.collectErrorEvent);
 router.get('/', ErrorController.getAllErrorEvents);
 export default router;

--- a/src/routes/Issue.ts
+++ b/src/routes/Issue.ts
@@ -4,10 +4,11 @@ import CommentController from '../controllers/CommentController';
 
 const router: express.Router = express();
 router.get('/', IssueController.listAllIssues);
-
+router.get('/:issueId', IssueController.issueDetail);
 // comment CRUD
 router.post('/comment', CommentController.addComment);
 router.put('/comment', CommentController.editComment);
 router.delete('/:issueId/comment/:commentId', CommentController.deleteComment);
 
+router.get('/project/:projectId', IssueController.listProjectIssues);
 export default router;

--- a/src/services/ErrorEventService.ts
+++ b/src/services/ErrorEventService.ts
@@ -22,3 +22,13 @@ export const getAllErrorEvent = async () => {
   const res: ErrorEventDocument[] = await ErrorEvent.find().exec();
   return res;
 };
+export const getErrorEventByIssueId = async (
+  issueId: mongoose.Types.ObjectId
+) => {
+  const res: ErrorEventDocument[] = await ErrorEvent.find({
+    issueId,
+  })
+    .sort({ date: -1 })
+    .exec();
+  return res;
+};

--- a/src/services/ErrorEventService.ts
+++ b/src/services/ErrorEventService.ts
@@ -1,19 +1,20 @@
 import * as crpyto from 'crypto';
+import * as mongoose from 'mongoose';
 import ErrorEvent, { ErrorEventDocument } from '../models/ErrorEvent';
 
 export const saveErrorEvent = async (LogData: {}) => {
   const hash: string = crpyto
     .createHash('md5')
     // eslint-disable-next-line dot-notation
-    .update(LogData['content'])
+    .update(LogData['stack'])
     .digest('hex');
   const newErrorEvent = new ErrorEvent({ ...LogData, hash });
   await newErrorEvent.save();
   return newErrorEvent;
 };
 
-export const getErrorEvent = async (eventId: String) => {
-  const res: ErrorEventDocument = await ErrorEvent.findById(eventId).exec();
+export const getErrorEvent = async (errorEventId: String) => {
+  const res: ErrorEventDocument = await ErrorEvent.findById(errorEventId);
   return res;
 };
 

--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -63,7 +63,7 @@ export const addErrorEventToISsue = async (errorEvent: ErrorEventDocument) => {
   return appendErrorEventToIssue(errorEvent);
 };
 
-export const getIssueListOfProject = async (
+export const getIssueListByProjectId = async (
   projectId: mongoose.Types.ObjectId
 ) => {
   const res: IssueDocument[] = await Issue.find({ projectId }).exec();

--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -1,3 +1,4 @@
+import * as mongoose from 'mongoose';
 import Issue, { IssueDocument } from '../models/Issue';
 import { ErrorEventDocument } from '../models/ErrorEvent';
 
@@ -7,6 +8,7 @@ export const createIssue = async (errorEvent: ErrorEventDocument) => {
   const msg = errorEvent.content.split('\n')[1];
 
   const newIssue = new Issue({
+    projectId: errorEvent.projectId,
     groupHash: errorEvent.hash,
     title,
     description: msg,
@@ -28,8 +30,8 @@ export const appendErrorEventToIssue = async (
   return res;
 };
 
-export const getIssue = async (groupHash: String) => {
-  const res: IssueDocument = await Issue.findOne({ groupHash }).exec();
+export const getIssue = async (issueId: String) => {
+  const res: IssueDocument = await Issue.findById(issueId).exec();
   return res;
 };
 
@@ -48,4 +50,11 @@ export const addErrorEventToISsue = async (errorEvent: ErrorEventDocument) => {
     return createIssue(errorEvent);
   }
   return appendErrorEventToIssue(errorEvent);
+};
+
+export const getIssueListOfProject = async (
+  projectId: mongoose.Types.ObjectId
+) => {
+  const res: IssueDocument[] = await Issue.find({ projectId }).exec();
+  return res;
 };

--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -1,22 +1,29 @@
 import * as mongoose from 'mongoose';
 import Issue, { IssueDocument } from '../models/Issue';
-import { ErrorEventDocument } from '../models/ErrorEvent';
+import ErrorEvent, { ErrorEventDocument } from '../models/ErrorEvent';
 
 // 기존 issue가 없을 경우 새로 만들어낸다
 export const createIssue = async (errorEvent: ErrorEventDocument) => {
-  const title = errorEvent.content.split('\n')[0];
-  const msg = errorEvent.content.split('\n')[1];
+  const { name } = errorEvent;
+  const { message } = errorEvent;
+  const { stack } = errorEvent;
 
   const newIssue = new Issue({
     projectId: errorEvent.projectId,
     groupHash: errorEvent.hash,
-    title,
-    description: msg,
+    name,
+    message,
+    stack,
     comments: [],
     errorEvents: [errorEvent],
   });
 
   const result: IssueDocument = await newIssue.save();
+
+  errorEvent.issueId = result._id;
+
+  await errorEvent.save();
+
   return result;
 };
 
@@ -25,8 +32,12 @@ export const appendErrorEventToIssue = async (
 ) => {
   const res: IssueDocument = await Issue.findOneAndUpdate(
     { groupHash: errorEvent.hash },
-    { $push: { errorEvents: errorEvent } }
+    // eslint-disable-next-line no-underscore-dangle
+    { $push: { errorEvents: errorEvent._id } }
   );
+
+  errorEvent.issueId = res._id;
+  await errorEvent.save();
   return res;
 };
 

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import Project, { ProjectDocument } from '../models/Project';
 import User, { UserDocument } from '../models/User';
 
@@ -14,6 +15,10 @@ const createProject = async (user: any, data: any) => {
 
   try {
     const project: ProjectDocument = await Project.create(docs);
+
+    project.dsn += `/${project._id}`;
+    await project.save();
+
     const updatedUser: UserDocument = await User.findByIdAndUpdate(
       userId,
       {


### PR DESCRIPTION
1. dsn 적용 
   - 프로젝트를 먼저 생성해서 projectId 값을 얻어온 뒤 dsn 설정하고  에러 수집
    - acent.init에 들어갈 dsn 형식 :   `host/errorevent/:projectId 
    - **host: 서버 주소**
    - **projectId: 프로젝트 생성시 만들어진 project document의 _id 값**

``` javascript

acent.init({
  dsn: 'http://localhost:3000/errorevent/5fcd707549015b405422e3d2',
});
```
 
2. ErrorEvent , Issue document에 해당 project id 저장하도록 적용

3. issue 관련  api 추가
` /issue/:issueId `
_id가 issueId에 해당하는 issue document 반환 
` /issue/project/:projectId ` 
projectId에 해당하는 모든 Issue document list반환


# 다음 추가/수정할 사항
- front 구현하면서 필요한 errorEvent, issue 관련 api 추가 구현
- embedding된 issue의 errorEvent document list 제거, reference 방식으로 변경 
