### PR TITLE
이슈 담당자 지정/변경 , 이슈 해결상태 변경 api 추가 

### DIFF
--- a/src/controllers/IssueController.ts
+++ b/src/controllers/IssueController.ts
@@ -26,4 +26,33 @@ const listProjectIssues = async (
   res.json(issuelist);
 };
 
-export default { listAllIssues, issueDetail, listProjectIssues };
+const issueAssign = async (req: express.Request, res: express.Response) => {
+  const issueId = new mongoose.Types.ObjectId(req.body.issueId);
+  const { assignee } = req.body;
+
+  const updatedIssue: IssueDocument = await issueService.setAssignee(
+    issueId,
+    assignee ? new mongoose.Types.ObjectId(assignee) : null
+  );
+  res.json(updatedIssue);
+};
+const issueResolvedState = async (
+  req: express.Request,
+  res: express.Response
+) => {
+  const issueId = new mongoose.Types.ObjectId(req.body.issueId);
+  const { resolved } = req.body;
+  const updatedIssue: IssueDocument = await issueService.setResolvedState(
+    issueId,
+    resolved
+  );
+  res.json(updatedIssue);
+};
+
+export default {
+  listAllIssues,
+  issueDetail,
+  listProjectIssues,
+  issueAssign,
+  issueResolvedState,
+};

--- a/src/controllers/ProjectController.ts
+++ b/src/controllers/ProjectController.ts
@@ -26,6 +26,22 @@ const getProject = async (req: express.Request, res: express.Response) => {
   }
 };
 
+const getJoinedProject = async (
+  req: express.Request,
+  res: express.Response
+) => {
+  try {
+    const result:
+      | ProjectDocument
+      | any = await ProjectService.readProjectWithPopulate(
+      req.user,
+      req.params.projectId
+    );
+    res.json(result);
+  } catch (err) {
+    res.json(err);
+  }
+};
 const deleteProject = async (req: express.Request, res: express.Response) => {
   try {
     const result: ProjectDocument = await ProjectService.removeProject(
@@ -67,6 +83,7 @@ const deleteMember = async (req: express.Request, res: express.Response) => {
 export default {
   postProject,
   getProject,
+  getJoinedProject,
   deleteProject,
   postMember,
   deleteMember,

--- a/src/models/Issue.ts
+++ b/src/models/Issue.ts
@@ -9,6 +9,10 @@ const IssueSchema: mongoose.Schema = new mongoose.Schema(
       required: true,
       trim: true,
     },
+    resolved: {
+      type: Boolean,
+      default: false,
+    },
     message: {
       type: String,
     },
@@ -28,6 +32,10 @@ const IssueSchema: mongoose.Schema = new mongoose.Schema(
         ref: 'ErrorEvent',
       },
     ],
+    assignee: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+    },
     comments: [CommentSchema],
   },
   {
@@ -43,6 +51,7 @@ export interface IssueDocument extends mongoose.Document {
   comments: CommentDocument[];
   errorEvents: mongoose.Types.ObjectId[];
   projectId: mongoose.Types.ObjectId;
+  resolved: Boolean;
 }
 
 const Issue: mongoose.Model<IssueDocument> = mongoose.model(

--- a/src/routes/Issue.ts
+++ b/src/routes/Issue.ts
@@ -5,6 +5,9 @@ import CommentController from '../controllers/CommentController';
 const router: express.Router = express();
 router.get('/', IssueController.listAllIssues);
 router.get('/:issueId', IssueController.issueDetail);
+router.put('/assignee', IssueController.issueAssign);
+router.put('/resolved', IssueController.issueResolvedState);
+
 // comment CRUD
 router.post('/comment', CommentController.addComment);
 router.put('/comment', CommentController.editComment);

--- a/src/routes/ProjectRoute.ts
+++ b/src/routes/ProjectRoute.ts
@@ -5,6 +5,7 @@ const router: express.Router = express();
 
 router.post('/', ProjectController.postProject);
 router.get('/:projectId', ProjectController.getProject);
+router.get('/v2/:projectId', ProjectController.getJoinedProject);
 router.delete('/:projectId', ProjectController.deleteProject);
 router.post('/:projectId/member', ProjectController.postMember);
 router.delete('/:projectId/member/:memberId', ProjectController.deleteMember);

--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -69,3 +69,26 @@ export const getIssueListByProjectId = async (
   const res: IssueDocument[] = await Issue.find({ projectId }).exec();
   return res;
 };
+
+export const setAssignee = async (
+  issueId: mongoose.Types.ObjectId,
+  assignee: mongoose.Types.ObjectId
+) => {
+  const filter = { _id: issueId };
+  const update = { assignee };
+  const res: IssueDocument = await Issue.findOneAndUpdate(filter, update, {
+    new: true,
+  });
+  return res;
+};
+export const setResolvedState = async (
+  issueId: mongoose.Types.ObjectId,
+  resolved: Boolean
+) => {
+  const filter = { _id: issueId };
+  const update = { resolved };
+  const res: IssueDocument = await Issue.findOneAndUpdate(filter, update, {
+    new: true,
+  });
+  return res;
+};

--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -43,7 +43,8 @@ export const appendErrorEventToIssue = async (
 };
 
 export const getIssue = async (issueId: String) => {
-  const res: IssueDocument = await Issue.findById(issueId).exec();
+  const issueDoc: IssueDocument = await Issue.findById(issueId).exec();
+  const res = await issueDoc.populate('projectId').execPopulate();
   return res;
 };
 

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -41,6 +41,24 @@ const readProject = async (user: any, projectId: string) => {
   return 'no permission';
 };
 
+// object id에 해당하는 document를 모두 join하여 반환
+const readProjectWithPopulate = async (user: any, projectId: string) => {
+  const { userId } = user;
+  const project: ProjectDocument = await Project.findById(projectId);
+  if (String(project.owner) === userId || project.members.includes(userId))
+    return project
+      .populate('owner')
+      .populate('members')
+      .populate({
+        path: 'issues',
+        populate: {
+          path: 'errorEvents',
+        },
+      })
+      .execPopulate();
+  return 'no permission';
+};
+
 const removeProject = async (user: any, projectId: string) => {
   const deletedProject: ProjectDocument = await Project.findOneAndDelete({
     _id: projectId,
@@ -116,6 +134,7 @@ const removeMember = async (user: any, projectId: string, memberId: string) => {
 export default {
   createProject,
   readProject,
+  readProjectWithPopulate,
   removeProject,
   pushMember,
   removeMember,


### PR DESCRIPTION
## 추가된 api

이슈 해결상태 변경하는 rest api
**PUT /issue/resolved**
``` javascript
{
issueId: issue의 document id
resolved: true/false 값 
}
```
이슈 담당자 지정/변경하는 api
**PUT /issue/assignee**
``` javascript
{
issueId: issue의 document id
assignee: 이슈 담당자로 지정할 user의 document id
}
```
projectId에 해당하는 project docment 반환시 join 적용하여 반환 
**GET /project/v2/:projectId**


