### PR TITLE
issue 해결상태, 마감기한 수정 api 개선, 각종 버그수정

### DIFF
--- a/src/controllers/IssueController.ts
+++ b/src/controllers/IssueController.ts
@@ -1,12 +1,59 @@
 import * as express from 'express';
 import * as mongoose from 'mongoose';
-import Issue, { IssueDocument } from '../models/Issue';
+import Issue, { IssueDocument, IssueResolveStateInfo } from '../models/Issue';
 import * as issueService from '../services/IssueService';
 
 const listAllIssues = async (req: express.Request, res: express.Response) => {
   const issueList: IssueDocument[] = await issueService.getAllIssue();
   res.json(issueList);
 };
+/*
+const listAllIssuesWithPagination = async (req: express.Request, res: express.Response) => {
+  // 페이지당 issue 개수
+  const itemNumPerPage = 10;
+
+  const { page, limit, order, resolved, asignee } = req.query;
+
+  const pageOptions = {
+    page: parseInt(page as string, 10) || 1,
+    limit: parseInt(limit as string, 10) || 10,
+  }; // order event 개수, 최신순, 오래된순,
+  let sortQuery = null;
+  switch (order) {
+    case 'new':
+      sortQuery = { updatedAt: 'desc' };
+      break;
+    case 'old':
+      sortQuery = { updatedAt: 'asc' };
+      break;
+    case 'event':
+      sortQuery = { errorEvents: 'asc' };
+      break;
+    default:
+      sortQuery = { updatedAt: 'desc' };
+      break;
+  }
+
+  const queryCond = {
+    ...(resolved && { resolved: Boolean(resolved) }),
+    ...(asignee && { asignee: String(asignee) }),
+  };
+  console.log(queryCond, pageOptions, sortQuery);
+
+  const resPage: {
+    issueDocList: IssueDocument[];
+    pageinfo: {
+      pageNum: number;
+      totalItemNum: number;
+    };
+  } = await issueService.getIssueListWithPagination(
+    pageOptions,
+    queryCond,
+    sortQuery
+  );
+  res.json(resPage);
+};
+*/
 
 const issueDetail = async (req: express.Request, res: express.Response) => {
   const { issueId } = req.params;
@@ -28,25 +75,30 @@ const listProjectIssues = async (
 
 const issueAssign = async (req: express.Request, res: express.Response) => {
   const issueId = new mongoose.Types.ObjectId(req.body.issueId);
+  const projectId = new mongoose.Types.ObjectId(req.params.projectId);
   const { assignee } = req.body;
 
   const updatedIssue: IssueDocument = await issueService.setAssignee(
+    projectId,
     issueId,
     assignee ? new mongoose.Types.ObjectId(assignee) : null
   );
   res.json(updatedIssue);
 };
+
 const issueResolvedState = async (
   req: express.Request,
   res: express.Response
 ) => {
-  const issueId = new mongoose.Types.ObjectId(req.body.issueId);
-  const { resolved } = req.body;
-  const updatedIssue: IssueDocument = await issueService.setResolvedState(
-    issueId,
-    resolved
+  const projectId = new mongoose.Types.ObjectId(req.params.projectId);
+  const resolveStateInfo: IssueResolveStateInfo = req.body;
+
+  const updateRes: any = await issueService.setResolvedState(
+    projectId,
+    resolveStateInfo
   );
-  res.json(updatedIssue);
+
+  res.json(updateRes);
 };
 
 export default {

--- a/src/controllers/LoginController.ts
+++ b/src/controllers/LoginController.ts
@@ -19,7 +19,7 @@ const googleLogin = (req: express.Request, res: express.Response) => {
       if (!userStatus) throw new Error('deleted user');
 
       if (token) {
-        res.cookie('jwt', token, { domain: 'localhost', httpOnly: true });
+        res.cookie('jwt', token, { httpOnly: true });
         return res.redirect(process.env.ADMIN_ADDR_MAIN);
       }
 
@@ -41,7 +41,7 @@ const githubLogin = (req: express.Request, res: express.Response) => {
       if (!userStatus) throw new Error('deleted user');
 
       if (token) {
-        res.cookie('jwt', token, { domain: 'localhost', httpOnly: true });
+        res.cookie('jwt', token, { httpOnly: true });
         return res.redirect(process.env.ADMIN_ADDR_MAIN);
       }
 
@@ -65,7 +65,7 @@ const naverLogin = async (req: express.Request, res: express.Response) => {
       LoginService.saveData(user, 'naver');
 
       if (token) {
-        res.cookie('jwt', token, { domain: 'localhost', httpOnly: true });
+        res.cookie('jwt', token, { httpOnly: true });
         return res.redirect(process.env.ADMIN_ADDR_MAIN);
       }
 

--- a/src/models/Issue.ts
+++ b/src/models/Issue.ts
@@ -53,7 +53,10 @@ export interface IssueDocument extends mongoose.Document {
   projectId: mongoose.Types.ObjectId;
   resolved: Boolean;
 }
-
+export interface IssueResolveStateInfo {
+  issueIdList: mongoose.Types.ObjectId[];
+  resolved: Boolean;
+}
 const Issue: mongoose.Model<IssueDocument> = mongoose.model(
   'Issue',
   IssueSchema

--- a/src/routes/Issue.ts
+++ b/src/routes/Issue.ts
@@ -5,8 +5,8 @@ import CommentController from '../controllers/CommentController';
 const router: express.Router = express();
 router.get('/', IssueController.listAllIssues);
 router.get('/:issueId', IssueController.issueDetail);
-router.put('/assignee', IssueController.issueAssign);
-router.put('/resolved', IssueController.issueResolvedState);
+router.put('/project/:projectId/assignee', IssueController.issueAssign);
+router.put('/project/:projectId/resolved', IssueController.issueResolvedState);
 
 // comment CRUD
 router.post('/comment', CommentController.addComment);

--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -32,9 +32,11 @@ export const appendErrorEventToIssue = async (
   errorEvent: ErrorEventDocument
 ) => {
   const res: IssueDocument = await Issue.findOneAndUpdate(
-    { groupHash: errorEvent.hash },
+    { projectId: errorEvent.projectId, groupHash: errorEvent.hash },
     // eslint-disable-next-line no-underscore-dangle
-    { $push: { errorEvents: errorEvent._id } },
+    {
+      $push: { errorEvents: errorEvent._id },
+    },
     { new: true }
   );
 


### PR DESCRIPTION
# 버그 수정 
### 다른 프로젝트에 같은 groupHash값을 가진 issue가 존재 가능하여 발생하는 버그 수정
  
기존에는 errorEvent hash값이 같으면 프로젝트가 달라도 같은 hash값을 가진 issue로 들어감  
같은 projectId와 stack의 md5 hash값을 기준으로 어느 issue로 들어갈지 판단하도록 수정  

stack + projectid의 md5 hash값으로 알고리즘을 변경하여 프로젝트 관계없이 issue가 고유한 groupHash 값을 가지도록 할 수 있음
-  수정하게 될경우 기존 db에 저장된 데이터를 전부 버려야 하고 백엔드에서 수정해야 할 사항이 만만치 않으므로 추후 다같이 논의해 볼 필요성이 있음

### jwt cookie domain 설정 삭제
domain이 localhost로 설정되면 로컬에서 테스트할때는 쿠키값을 브라우저에서 이용할 수 있지만 배포환경에서는 불가
domain 설정을 삭제하면 자동으로 실행되는 host로 도메인이 설정됨 

# issue 해결상태, 마감기한 수정 api 개선 


## issue 해결상태 api 

- issue 마감기한 변경 : projectId 조건 추가, 여러 issue를 동시에 수정 가능
- ` PUT /project/:projectId/resolved ` 로 url 변경
- input 형식 변경 
  - issueIdList : 상태를 변경하고자 하는 issue들의 id list
  - resolved : 변경하고자 하는 상태값 true/false
``` javascript
{
"issueIdList": ["5fd1d1d49caac014a0c7eb18", "5fd1d1d49caac014a0c7eb19", "5fd1d2059caac014a0c7eb1b" ],
"resolved":true
}
```

## issue 담당자 변경 api
-  ` PUT /project/:projectId/assignee ` 로  url 변경
- issue 담당자 변경 : projectId 조건 추가
