### PR TITLE
alert(새 이슈발생시) , 메일전송,  issue pagination 구현

### DIFF
--- a/src/controllers/AlertController.ts
+++ b/src/controllers/AlertController.ts
@@ -1,6 +1,6 @@
 import * as express from 'express';
 import * as mongoose from 'mongoose';
-import { AlertDocument } from '../models/AlertEvent';
+import { AlertDocument } from '../models/Alert';
 import AlertService from '../services/AlertService';
 
 const listAlerts = async (req: express.Request, res: express.Response) => {

--- a/src/controllers/AlertController.ts
+++ b/src/controllers/AlertController.ts
@@ -1,0 +1,11 @@
+import * as express from 'express';
+import * as mongoose from 'mongoose';
+import { AlertDocument } from '../models/AlertEvent';
+import AlertService from '../services/AlertService';
+
+const listAlerts = async (req: express.Request, res: express.Response) => {
+  const alertDocs: AlertDocument[] = await AlertService.getAlertList(req.user);
+  return res.json(alertDocs);
+};
+
+export default { listAlerts };

--- a/src/mailConfig.ts
+++ b/src/mailConfig.ts
@@ -1,0 +1,23 @@
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env' });
+
+/**
+ *
+ * nodemailer 설정
+ * google 하루 전송량 500개로 제한되어 네이버 기준으로 구현
+ */
+
+const config = {
+  port: process.env.SMTP_PORT, // smtp 서버 포트 네이버 : 587
+  smtpServerURL: process.env.SMTP_SERVER_URL, // smtp서버 url 네이버 :smtp.naver.com
+  authUser: process.env.SMTP_AUTH_USER, // smtp 메일계정 -본인 네이버 메일
+  authPass: process.env.SMTP_AUTH_PASS, // smtp 메일계정 비밀번호 - 본인 네이버계정비밀번호
+  fromEmail: process.env.MAIL_FROM.replace(
+    // 발신자 표시
+    '${SMTP_AUTH_USER}',
+    process.env.SMTP_AUTH_USER
+  ),
+  service: process.env.MAIL_SERVICE, // 서비스명 네이버 :Naver
+};
+export default config;

--- a/src/models/Alert.ts
+++ b/src/models/Alert.ts
@@ -1,0 +1,49 @@
+import * as mongoose from 'mongoose';
+
+export const AlertSchema: mongoose.Schema = new mongoose.Schema(
+  {
+    alertType: {
+      type: mongoose.Schema.Types.Mixed,
+      required: true,
+    },
+
+    issue: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Issue',
+      default: null,
+    },
+
+    from: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Issue',
+      default: null,
+    },
+
+    project: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Project',
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+export interface AlertType extends Object {
+  name: String;
+  title: String;
+}
+export interface AlertDocument extends mongoose.Document {
+  alertType: AlertType;
+  issue: mongoose.Types.ObjectId;
+  from: mongoose.Types.ObjectId;
+  project: mongoose.Types.ObjectId;
+  createdAt: Date;
+}
+
+const Alert: mongoose.Model<AlertDocument> = mongoose.model(
+  'Alert',
+  AlertSchema
+);
+
+export default Alert;

--- a/src/models/Issue.ts
+++ b/src/models/Issue.ts
@@ -1,6 +1,7 @@
 import * as mongoose from 'mongoose';
-import { ErrorEventSchema, ErrorEventDocument } from './ErrorEvent';
 import { CommentSchema, CommentDocument } from './Comment';
+// import * as mongoosePaginate from 'mongoose-paginate-v2';
+const mongooseAggregatePaginate = require('mongoose-aggregate-paginate-v2');
 
 const IssueSchema: mongoose.Schema = new mongoose.Schema(
   {
@@ -25,6 +26,7 @@ const IssueSchema: mongoose.Schema = new mongoose.Schema(
     },
     groupHash: {
       type: String,
+      index: true,
     },
     errorEvents: [
       {
@@ -42,7 +44,7 @@ const IssueSchema: mongoose.Schema = new mongoose.Schema(
     timestamps: true,
   }
 );
-
+IssueSchema.index({ createdAt: -1 });
 export interface IssueDocument extends mongoose.Document {
   name: String;
   message: String;
@@ -52,12 +54,15 @@ export interface IssueDocument extends mongoose.Document {
   errorEvents: mongoose.Types.ObjectId[];
   projectId: mongoose.Types.ObjectId;
   resolved: Boolean;
+  createdAt: Date;
 }
 export interface IssueResolveStateInfo {
   issueIdList: mongoose.Types.ObjectId[];
   resolved: Boolean;
 }
-const Issue: mongoose.Model<IssueDocument> = mongoose.model(
+
+IssueSchema.plugin(mongooseAggregatePaginate);
+const Issue: mongoose.AggregatePaginateModel<IssueDocument> = mongoose.model(
   'Issue',
   IssueSchema
 );

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -43,9 +43,9 @@ export interface ProjectDocument extends mongoose.Document {
   description: String;
   platform: String;
   dsn: String;
-  owner: mongoose.Schema.Types.ObjectId;
-  members: Array<mongoose.Schema.Types.ObjectId>;
-  issues: Array<mongoose.Schema.Types.ObjectId>;
+  owner: mongoose.Types.ObjectId;
+  members: Array<mongoose.Types.ObjectId>;
+  issues: Array<mongoose.Types.ObjectId>;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -38,8 +38,8 @@ export interface UserDocument extends mongoose.Document {
   imageURL: String;
   oauthId: String;
   status: Boolean;
-  projects: Array<mongoose.Schema.Types.ObjectId>;
-  recentProject: mongoose.Schema.Types.ObjectId;
+  projects: Array<mongoose.Types.ObjectId>;
+  recentProject: mongoose.Types.ObjectId;
 }
 
 const User: mongoose.Model<UserDocument> = mongoose.model('User', userSchema);

--- a/src/routes/Alert.ts
+++ b/src/routes/Alert.ts
@@ -1,0 +1,7 @@
+import * as express from 'express';
+import AlertController from '../controllers/AlertController';
+
+const router: express.Router = express();
+router.get('/', AlertController.listAlerts);
+
+export default router;

--- a/src/routes/Issue.ts
+++ b/src/routes/Issue.ts
@@ -4,6 +4,7 @@ import CommentController from '../controllers/CommentController';
 
 const router: express.Router = express();
 router.get('/', IssueController.listAllIssues);
+
 router.get('/:issueId', IssueController.issueDetail);
 router.put('/assignee/:projectId', IssueController.issueAssign);
 router.put('/resolved', IssueController.issueResolvedState);
@@ -14,4 +15,9 @@ router.put('/comment', CommentController.editComment);
 router.delete('/:issueId/comment/:commentId', CommentController.deleteComment);
 
 router.get('/project/:projectId', IssueController.listProjectIssues);
+router.get(
+  '/v2/project/:projectId',
+  IssueController.getProjectIssuesWitPagination
+);
+
 export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@ import errorEventRouter from './Error';
 import issueRouter from './Issue';
 import projectRouter from './ProjectRoute';
 import userRouter from './UserRoute';
+import alertRouter from './Alert';
 
 const router: express.Router = express();
 router.use('/oauth', loginRouter);
@@ -25,6 +26,11 @@ router.use(
   '/user',
   passport.authenticate('jwt', { session: false }),
   userRouter
+);
+router.use(
+  '/alert',
+  passport.authenticate('jwt', { session: false }),
+  alertRouter
 );
 
 router.get('/', (req: express.Request, res: express.Response) => {

--- a/src/services/AlertService.ts
+++ b/src/services/AlertService.ts
@@ -1,0 +1,75 @@
+import * as mongoose from 'mongoose';
+import AlertEvent, { AlertDocument, AlertType } from '../models/AlertEvent';
+import { IssueDocument } from '../models/Issue';
+import User from '../models/User';
+import MailService from './MailService';
+import ProjectService from './ProjectService';
+
+const addNewAlertEvent = async (
+  user: mongoose.Types.ObjectId | null,
+  newIssue: IssueDocument
+) => {
+  const newIssueType: AlertType = {
+    name: 'newIssue',
+    title: '새로운 이슈 발생',
+  };
+
+  const newAlertDoc = {
+    alertType: newIssueType,
+    // eslint-disable-next-line no-underscore-dangle
+    issue: newIssue._id,
+    from: user,
+    project: newIssue.projectId,
+  };
+
+  const newAlert: AlertDocument = new AlertEvent(newAlertDoc);
+  const res = await newAlert.save();
+
+  const memberList: any = await ProjectService.getProjectMemberList(
+    newIssue.projectId.toHexString()
+  );
+
+  memberList.forEach(member => {
+    const mailTemplate = `
+  <h2> 새로운 issue 발생  </h2>
+  <h3> ${newIssue.name}  - ${newIssue.message}  </h3>
+  <h4> 발생 시각 : ${new Date(newIssue.createdAt).toLocaleString()}  </h4>
+
+  <h3> STACK MESSAGE  </h3>
+  <div>
+   ${newIssue.stack}
+  </div>
+  
+  <a href="http://${process.env.FRONT_HOST}/issues/${
+      // eslint-disable-next-line no-underscore-dangle
+      newIssue._id
+    }" >해당 issue page로 이동하기</a>
+  `;
+    if (member.email)
+      MailService.sendEmail(member.email, 'issue 발생함', mailTemplate);
+  });
+
+  return res;
+};
+
+const getAlertList = async (user: any) => {
+  const userId: mongoose.Types.ObjectId = new mongoose.Types.ObjectId(
+    user.userId
+  );
+
+  const { projects } = await User.findOne({ _id: userId });
+
+  const res: AlertDocument[] = await AlertEvent.find({
+    project: { $in: projects },
+  })
+    .populate({
+      path: 'project',
+      model: 'Project',
+      select: '_id title',
+    })
+    .exec();
+
+  return res;
+};
+
+export default { addNewAlertEvent, getAlertList };

--- a/src/services/AlertService.ts
+++ b/src/services/AlertService.ts
@@ -1,5 +1,5 @@
 import * as mongoose from 'mongoose';
-import AlertEvent, { AlertDocument, AlertType } from '../models/AlertEvent';
+import AlertEvent, { AlertDocument, AlertType } from '../models/Alert';
 import { IssueDocument } from '../models/Issue';
 import User from '../models/User';
 import MailService from './MailService';

--- a/src/services/MailService.ts
+++ b/src/services/MailService.ts
@@ -1,0 +1,30 @@
+import * as nodemailer from 'nodemailer';
+import * as dotenv from 'dotenv';
+import config from '../mailConfig';
+import Mail = require('nodemailer/lib/mailer');
+
+const { smtpServerURL, authUser, authPass, fromEmail, service, port } = config;
+
+async function sendEmail(toEmail, title, html) {
+  const transporter: Mail = nodemailer.createTransport({
+    service,
+    port: parseInt(port, 10),
+    host: smtpServerURL, // SMTP 서버 주소
+    auth: {
+      user: authUser, // 메일서버 계정
+      pass: authPass, // 메일서버 비번
+    },
+  });
+
+  const mailOptions = {
+    from: fromEmail, // 보내는 사람 주소
+    to: toEmail, // 받는 사람 주소
+    subject: title, // 제목
+    html, // 본문
+  };
+
+  const res = await transporter.sendMail(mailOptions);
+  return res;
+}
+
+export default { sendEmail };

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -59,6 +59,19 @@ const readProjectWithPopulate = async (user: any, projectId: string) => {
   return 'no permission';
 };
 
+// 특정 프로젝트의 구성인원 모두에 대한 정보를 반환
+const getProjectMemberList = async (projectId: string) => {
+  const projectDocument = await Project.findOne({
+    _id: projectId,
+  })
+    .populate('members')
+    .exec();
+
+  const { members } = projectDocument;
+  const projectMemberList = [...members];
+  return projectMemberList;
+};
+
 const removeProject = async (user: any, projectId: string) => {
   const deletedProject: ProjectDocument = await Project.findOneAndDelete({
     _id: projectId,
@@ -138,4 +151,5 @@ export default {
   removeProject,
   pushMember,
   removeMember,
+  getProjectMemberList,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "target": "ES5",
     "module": "CommonJS",
     "moduleResolution": "node",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
1. 메일전송 기능 추가 

- nodemailer 사용
- 구글은 발송제한이 하루 500건, 네이버는 5000건정도이거나 없는것 같아 네이버 계정 이용하는것이 좋다고 판단, 네이버 기준으로 구현
- env에 아래 변수 추가하고 네이버 이메일과 네이버 계정 비번만 본인것으로 수정하면 됨
``` env
################################EMAIL##################################
SMTP_PORT=587   
SMTP_SERVER_URL=smtp.naver.com 
SMTP_AUTH_USER=네이버이메일
SMTP_AUTH_PASS=네이버계정비번
MAIL_FROM=ACENT INFO 👥 <${SMTP_AUTH_USER}>
MAIL_SERVICE=Naver
```
2. alert 기능 
- 새 이슈 발생시 Alert 발생하여 해당 프로젝트의 모든 유저들에게 Alert 창에서 보여줌
- 새 이슈 발생시  issue 내용을 해당 프로젝트의 모든 유저들에게 메일 발송 
GET /alert 
로그인 유저에게 온 Alert List를 반환 - 다음과 같은 형식의 Alert의 List를 반환
``` javascript
{
issue: "5fd7a571fb02672b5cc17596",
from: null,
_id: "5fd7a571fb02672b5cc17597",
alertType: {
name: "newIssue",
title: "새로운 이슈 발생"
},
project: {
_id: "5fd06b4c98cd751efc1f4e24",
title: "testtetst22"
},
createdAt: "2020-12-14T17:48:33.761Z",
updatedAt: "2020-12-14T17:48:33.761Z",
__v: 0
},
```
3. issue pagination 구현
GET :/issue/v2/project/:projectId
페이지네이션이 적용된 project의 issue list를 반환한다 
반환 형식
``` javascript
{
docs: [issuelist],
totalDocs: issue 총 개수 ,
limit: 페이지당 제한 개수,
page: 현재 페이지,
totalPages: 총 페이지 수,
pagingCounter: 한번에 넘길 페이지 수,
hasPrevPage:  이전 페이지 존재 여부 true/false,
hasNextPage:  다음 페이지 존재 여부 true/false,
prevPage:  이전 페이지 (number /null),
nextPage:  다음 페이지 (number /null),
}
```


### query parmater로 다음과 같이 정렬과 필터링 가능
page=현재페이지
sort=정렬기준
- new : error event가 최근  발생된 issue 순서로(최신 issue)
- old :  error event가 오래전에 발생된 issue 순서로 (오래된 issue)
- eventdesc : issue에 속한  error event 수 많은 순으로 
- eventasc   : issue에 속한 error event 수 적은 순으로

resolved=해결상태여부 true/false
assignee=issue 담당자의 Objectid


