### PR TITLE
Stats API 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
+    "moment": "^2.29.1",
     "mongoose": "^5.10.15",
     "mongoose-aggregate-paginate-v2": "^1.0.42",
     "nodemailer": "^6.4.17",

--- a/src/controllers/ChartController.ts
+++ b/src/controllers/ChartController.ts
@@ -27,4 +27,16 @@ const getIssue = async (req: express.Request, res: express.Response) => {
   }
 };
 
-export default { getDailyError, getIssue };
+const getTag = async (req: express.Request, res: express.Response) => {
+  try {
+    const result = await ChartService.readTag(
+      req.user as ReqUserDocument,
+      req.params.projectId as string
+    );
+    res.json(result);
+  } catch (err) {
+    res.json(err);
+  }
+};
+
+export default { getDailyError, getIssue, getTag };

--- a/src/controllers/ChartController.ts
+++ b/src/controllers/ChartController.ts
@@ -15,4 +15,16 @@ const getDailyError = async (req: express.Request, res: express.Response) => {
   }
 };
 
-export default { getDailyError };
+const getIssue = async (req: express.Request, res: express.Response) => {
+  try {
+    const result = await ChartService.readIssue(
+      req.user as ReqUserDocument,
+      req.params.projectId as string
+    );
+    res.json(result);
+  } catch (err) {
+    res.json(err);
+  }
+};
+
+export default { getDailyError, getIssue };

--- a/src/controllers/ChartController.ts
+++ b/src/controllers/ChartController.ts
@@ -1,0 +1,18 @@
+import * as express from 'express';
+import ChartService from '../services/ChartService';
+import { ReqUserDocument } from '../models/User';
+
+const getDailyError = async (req: express.Request, res: express.Response) => {
+  try {
+    const result = await ChartService.readDailyError(
+      req.user as ReqUserDocument,
+      req.params.projectId as string,
+      req.query.day as string
+    );
+    res.json(result);
+  } catch (err) {
+    res.json(err);
+  }
+};
+
+export default { getDailyError };

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -42,6 +42,16 @@ export interface UserDocument extends mongoose.Document {
   recentProject: mongoose.Types.ObjectId;
 }
 
+export interface ReqUserDocument extends mongoose.Document {
+  userId: mongoose.Schema.Types.ObjectId;
+  name: String;
+  email: String;
+  imageURL: String;
+  status: Boolean;
+  projects: Array<mongoose.Schema.Types.ObjectId>;
+  recentProject: mongoose.Schema.Types.ObjectId;
+}
+
 const User: mongoose.Model<UserDocument> = mongoose.model('User', userSchema);
 
 export default User;

--- a/src/routes/ProjectRoute.ts
+++ b/src/routes/ProjectRoute.ts
@@ -1,5 +1,6 @@
 import * as express from 'express';
 import ProjectController from '../controllers/ProjectController';
+import ChartController from '../controllers/ChartController';
 
 const router: express.Router = express();
 
@@ -9,5 +10,6 @@ router.get('/v2/:projectId', ProjectController.getJoinedProject);
 router.delete('/:projectId', ProjectController.deleteProject);
 router.post('/:projectId/member', ProjectController.postMember);
 router.delete('/:projectId/member/:memberId', ProjectController.deleteMember);
+router.get('/:projectId/chart/dailyError', ChartController.getDailyError);
 
 export default router;

--- a/src/routes/ProjectRoute.ts
+++ b/src/routes/ProjectRoute.ts
@@ -11,5 +11,6 @@ router.delete('/:projectId', ProjectController.deleteProject);
 router.post('/:projectId/member', ProjectController.postMember);
 router.delete('/:projectId/member/:memberId', ProjectController.deleteMember);
 router.get('/:projectId/chart/dailyError', ChartController.getDailyError);
+router.get('/:projectId/chart/issue', ChartController.getIssue);
 
 export default router;

--- a/src/routes/ProjectRoute.ts
+++ b/src/routes/ProjectRoute.ts
@@ -12,5 +12,6 @@ router.post('/:projectId/member', ProjectController.postMember);
 router.delete('/:projectId/member/:memberId', ProjectController.deleteMember);
 router.get('/:projectId/chart/dailyError', ChartController.getDailyError);
 router.get('/:projectId/chart/issue', ChartController.getIssue);
+router.get('/:projectId/chart/tag', ChartController.getTag);
 
 export default router;

--- a/src/services/ChartService.ts
+++ b/src/services/ChartService.ts
@@ -1,0 +1,91 @@
+import * as moment from 'moment';
+import * as mongoose from 'mongoose';
+import { ReqUserDocument } from '../models/User';
+import ErrorEvent from '../models/ErrorEvent';
+
+const readDailyError = async (
+  user: ReqUserDocument,
+  projectId: string,
+  day: string
+) => {
+  if (!user.projects.some(project => String(project) === projectId))
+    return 'no permission';
+
+  const endDay = moment().endOf('day').toDate();
+  const startDay = moment(endDay)
+    .subtract(Number(day), 'days')
+    .startOf('day')
+    .toDate();
+  const correctionTime = 9 * 60 * 60000;
+
+  const tempErrorCounts = await ErrorEvent.aggregate([
+    {
+      $match: {
+        projectId: mongoose.Types.ObjectId(projectId),
+        date: { $gte: startDay, $lte: endDay },
+      },
+    },
+    { $project: { name: '$name', date: { $add: ['$date', correctionTime] } } },
+    {
+      $group: {
+        _id: {
+          name: '$name',
+          year: { $year: '$date' },
+          month: { $month: '$date' },
+          day: { $dayOfMonth: '$date' },
+        },
+        count: { $sum: 1 },
+      },
+    },
+    {
+      $project: {
+        year: { $convert: { input: '$_id.year', to: 'string' } },
+        month: { $convert: { input: '$_id.month', to: 'string' } },
+        day: { $convert: { input: '$_id.day', to: 'string' } },
+        count: '$count',
+      },
+    },
+    {
+      $project: {
+        date: { $concat: ['$year', '/', '$month', '/', '$day'] },
+        count: '$count',
+      },
+    },
+    {
+      $group: {
+        _id: {
+          name: '$_id.name',
+        },
+        dates: {
+          $push: {
+            date: '$date',
+            count: '$count',
+          },
+        },
+      },
+    },
+    { $sort: { '_id.name': 1 } },
+  ]);
+
+  let currentDate = moment(startDay).add(1, 'day').toDate();
+  const endDate = moment(endDay).toDate();
+  const dates = ['x'];
+  const errors = {};
+  tempErrorCounts.forEach(data => (errors[data._id.name] = [data._id.name]));
+
+  while (currentDate < endDate) {
+    const formatDate = moment(currentDate).format('YYYY/MM/DD');
+    dates.push(formatDate);
+    tempErrorCounts.forEach(data => {
+      const dateData = data.dates.find(date => date.date === formatDate);
+      const count = dateData ? dateData.count : 0;
+      errors[data._id.name].push(count);
+    });
+    currentDate = moment(currentDate).add(1, 'days').toDate();
+  }
+
+  const result = { dates, ...errors };
+  return result;
+};
+
+export default { readDailyError };

--- a/src/services/ChartService.ts
+++ b/src/services/ChartService.ts
@@ -156,7 +156,76 @@ const readIssue = async (user: ReqUserDocument, projectId: string) => {
   };
 };
 
+const readTag = async (user: ReqUserDocument, projectId: string) => {
+  if (!checkPermission(user, projectId)) return 'no permission';
+
+  const tagsArr = await ErrorEvent.find(
+    {
+      projectId: mongoose.Types.ObjectId(projectId),
+    },
+    { tags: 1 }
+  );
+
+  const browsers = {};
+  const platforms = {};
+  const osVersions = {};
+  const urls = {};
+  const methods = {};
+  const countIdx = 1;
+
+  tagsArr.forEach((item: any) => {
+    const {
+      tags: { browser, platform, osVersion, url, method },
+    } = item;
+
+    if (browser) {
+      if (browsers[browser]) {
+        browsers[browser][countIdx] += 1;
+      } else {
+        browsers[browser] = [browser, 1];
+      }
+    }
+    if (platform) {
+      if (platforms[platform]) {
+        platforms[platform][countIdx] += 1;
+      } else {
+        platforms[platform] = [platform, 1];
+      }
+    }
+    if (osVersion) {
+      if (osVersions[osVersion]) {
+        osVersions[osVersion][countIdx] += 1;
+      } else {
+        osVersions[osVersion] = [osVersion, 1];
+      }
+    }
+    if (url) {
+      if (urls[url]) {
+        urls[url][countIdx] += 1;
+      } else {
+        urls[url] = [url, 1];
+      }
+    }
+    if (method) {
+      if (methods[method]) {
+        methods[method][countIdx] += 1;
+      } else {
+        methods[method] = [method, 1];
+      }
+    }
+  });
+
+  return {
+    browsers: objToArr(browsers),
+    platforms: objToArr(platforms),
+    osVersions: objToArr(osVersions),
+    urls: objToArr(urls),
+    methods: objToArr(methods),
+  };
+};
+
 export default {
   readDailyError,
   readIssue,
+  readTag,
 };

--- a/src/services/ChartService.ts
+++ b/src/services/ChartService.ts
@@ -215,11 +215,11 @@ const readTag = async (user: ReqUserDocument, projectId: string) => {
   });
 
   return {
-    browsers: objToArr(browsers),
-    platforms: objToArr(platforms),
-    osVersions: objToArr(osVersions),
-    urls: objToArr(urls),
-    methods: objToArr(methods),
+    browser: objToArr(browsers),
+    platform: objToArr(platforms),
+    osVersion: objToArr(osVersions),
+    url: objToArr(urls),
+    method: objToArr(methods),
   };
 };
 

--- a/src/services/ChartService.ts
+++ b/src/services/ChartService.ts
@@ -9,12 +9,11 @@ const checkPermission = (user: ReqUserDocument, projectId: string): boolean => {
 };
 
 const objToArr = (obj: object): object[] => {
-  const arr = [];
-  Object.keys(obj).forEach(item => {
+  const arr = Object.keys(obj).map(item => {
     const temp = {};
     temp['name'] = item;
     temp['value'] = obj[item];
-    arr.push(temp);
+    return temp;
   });
   return arr;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,6 +1862,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 mongodb@3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.3.tgz#eddaed0cc3598474d7a15f0f2a5b04848489fd05"


### PR DESCRIPTION
**요약** 

Stats 페이지에서 사용할 데이터를 반환하는 API를 구현했습니다. 

**내용**

- 일일 에러 발생 횟수 정보를 가져올 수 있는 API를 추가했습니다. 
- 이슈 종류와 상태 정보를 가져올 수 있는 API를 추가했습니다. 
- 태그 종류 정보를 가져올 수 있는 API를 추가했습니다. 
- `moment` 모듈을 추가했습니다. 