### PR TITLE
배포용 dockerfile, docker-compose.yml 추가

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+# 부모 이미지 지정
+FROM node:14
+# 작업 디렉토리 생성
+WORKDIR /usr/src/app
+# 의존성 설치
+COPY ./package.json ./
+COPY ./yarn.lock ./
+RUN yarn
+RUN yarn global add pm2
+# 소스 추가
+COPY ./. .
+RUN yarn build
+# 포트 매핑
+EXPOSE 3000
+EXPOSE 27017
+
+
+# Add docker-compose-wait tool -------------------
+ENV WAIT_VERSION 2.7.2
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /wait
+RUN chmod +x /wait
+
+# 실행 명령
+CMD /wait && pm2-runtime start ecosystem.config.js --env production

--- a/docker/docker-compose-db.yml
+++ b/docker/docker-compose-db.yml
@@ -1,0 +1,22 @@
+version: '3' # 파일 규격 버전
+services: # 이 항목 밑에 실행하려는 컨테이너 들을 정의
+  # Use root/example as user/password credentials
+  mongo:
+    image: mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PW}
+    ports:
+      - 27017:27017
+    volumes:
+      - ./data/db:/data/db
+
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: ${MONGO_USER}
+      ME_CONFIG_MONGODB_ADMINPASSWORD: ${MONGO_PW}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3' # 파일 규격 버전
+version: '3.5' # 파일 규격 버전
 services: # 이 항목 밑에 실행하려는 컨테이너 들을 정의
   # Use root/example as user/password credentials
   mongo:
@@ -9,14 +9,57 @@ services: # 이 항목 밑에 실행하려는 컨테이너 들을 정의
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PW}
     ports:
       - 27017:27017
+    expose:
+      - 27017
     volumes:
       - ./data/db:/data/db
+    networks:
+      - backend
 
-  mongo-express:
-    image: mongo-express
+  nginx-react:
+    container_name: nginx-react
+    image: nginx-react
     restart: always
+    build: ../../Project11-C-Web-FE-Performance-Monitoring-Admin
     ports:
-      - 8081:8081
+      - '80:80'
+    networks:
+      - backend
+
+  pm2-express-1:
+    container_name: pm2-express-1
+    image: pm2-express
+    restart: always
+    build:
+      context: ..
+      dockerfile: ./docker/Dockerfile
+    ports:
+      - 3000:3000
+    networks:
+      - backend
+    depends_on:
+      - mongo
     environment:
-      ME_CONFIG_MONGODB_ADMINUSERNAME: ${MONGO_USER}
-      ME_CONFIG_MONGODB_ADMINPASSWORD: ${MONGO_PW}
+      - WAIT_HOSTS=mongo:27017
+      - WAIT_HOSTS_TIMEOUT=300
+      - WAIT_SLEEP_INTERVAL=15
+      - WAIT_HOST_CONNECT_TIMEOUT=15
+
+  pm2-express-2:
+    container_name: pm2-express-2
+    restart: always
+    image: pm2-express
+    ports:
+      - 3001:3000
+    networks:
+      - backend
+    depends_on:
+      - mongo
+    environment:
+      - WAIT_HOSTS=mongo:27017
+      - WAIT_HOSTS_TIMEOUT=300
+      - WAIT_SLEEP_INTERVAL=15
+      - WAIT_HOST_CONNECT_TIMEOUT=15
+networks:
+  backend:
+    driver: bridge

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  apps: [
+    {
+      name: 'acent_backend', // 이름. 나중에 이 이름으로 프로세스를 관리한다
+      script: 'dist/bin/www.js', // 실행할 파일 경로
+      instances: 0, // 클러스터 모드 사용 시 생성할 인스턴스 수
+      exec_mode: 'cluster', // fork, cluster 모드 중 선택
+      merge_logs: true, // 클러스터 모드 사용 시 각 클러스터에서 생성되는 로그를 한 파일로 합쳐준다.
+      autorestart: true, // 프로세스 실패 시 자동으로 재시작할지 선택
+      watch: true, // 파일이 변경되었을 때 재시작 할지 선택
+      max_memory_restart: '512M', // 프로그램의 메모리 크기가 일정 크기 이상이 되면 재시작한다.
+      env: {
+        // 개발 환경설정
+        PORT: 3000,
+        NODE_ENV: 'development',
+      },
+      env_production: {
+        // 운영 환경설정 (--env production 옵션으로 지정할 수 있다.)
+        PORT: 3000,
+        NODE_ENV: 'production',
+      },
+    },
+  ],
+};


### PR DESCRIPTION
기존 docker-compose.yml을  docker-compose-db.yml로 변경. mongodb 컨테이너만 빌드 및 실행시킬때 사용
docker-compose를 통해 프론트엔드, 백엔드 도커 이미지 빌드 및 컨테이너 실행을 통한 일괄 배포 가능
프론트엔드 :  Nginx +React.js 도커 이미지 빌드
  - 프론트엔드 git repo의 dockerfile을 실행시켜 빌드 
  - nginx에서 두개의 express.js 서버 로드밸런싱(pm2-express-1, pm2-express-2)
백엔드 :  mongodb , Express.js+pm2 도커 이미지 빌드
  - Express+pm2 이미지를 사용한 두개의 서버 컨테이너 실행
 